### PR TITLE
feat: expose retry timing in `AcmeError`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,12 +1,25 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
+    "jsr:@std/assert@*": "1.0.14",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
     "npm:@peculiar/x509@*": "1.12.3",
     "npm:@peculiar/x509@1.12": "1.12.3",
     "npm:@peculiar/x509@^1.12.3": "1.12.3",
     "npm:@types/node@*": "22.12.0",
     "npm:jose@5": "5.9.6",
     "npm:jose@^6.0.8": "6.0.8"
+  },
+  "jsr": {
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    }
   },
   "npm": {
     "@peculiar/asn1-cms@2.3.15": {

--- a/mod.ts
+++ b/mod.ts
@@ -494,8 +494,11 @@ export class Client {
       const contentType = resp.headers.get("Content-Type");
       if (contentType?.startsWith("application/json")) {
         const data: RenewalInfo = await resp.json();
-        const retryAfter = resp.headers.get("Retry-After");
-        if (retryAfter) data.retryAfter = parseInt(retryAfter);
+        const now = new Date();
+        const retryAfter = parseRetryAfter(resp.headers, now);
+        if (retryAfter && now < retryAfter) {
+          data.retryAfter = (retryAfter.getTime() - now.getTime()) / 1000;
+        }
         return data;
       } else {
         throw new Error("Unexpected content type: " + contentType);

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 import { createPublicKey, type KeyObject } from "node:crypto";
 import { base64url, calculateJwkThumbprint, FlattenedSign } from "jose";
+import { parseRetryAfter } from "./util.ts";
 
 interface Directory {
   newNonce: string;
@@ -508,7 +509,13 @@ export class Client {
         throw new HttpError(resp.status, text);
       }
       if (data.type && data.detail) {
-        throw new AcmeError(data.type, data.detail, data.subproblems || null);
+        const retryAfter = parseRetryAfter(resp.headers);
+        throw new AcmeError(
+          data.type,
+          data.detail,
+          data.subproblems || null,
+          retryAfter,
+        );
       } else {
         throw new HttpError(resp.status, text);
       }
@@ -631,7 +638,13 @@ export class Client {
         throw new HttpError(resp.status, text);
       }
       if (data.type && data.detail) {
-        throw new AcmeError(data.type, data.detail, data.subproblems || null);
+        const retryAfter = parseRetryAfter(resp.headers);
+        throw new AcmeError(
+          data.type,
+          data.detail,
+          data.subproblems || null,
+          retryAfter,
+        );
       } else {
         throw new HttpError(resp.status, text);
       }
@@ -680,16 +693,20 @@ export class AcmeError extends Error {
   detail: string;
   /** Additional subproblems that may have caused the error. */
   subproblems: AcmeSubproblem[] | null;
+  /** The date after which the operation should be retried. */
+  retryAfter: Date | null;
 
   constructor(
     type: string,
     detail: string,
     subproblems: AcmeSubproblem[] | null,
+    retryAfter: Date | null,
   ) {
     super(`${type}: ${detail}`);
     this.type = type;
     this.detail = detail;
     this.subproblems = subproblems;
+    this.retryAfter = retryAfter;
   }
 }
 

--- a/util.ts
+++ b/util.ts
@@ -5,6 +5,19 @@
 export function parseRetryAfter(headers: Headers, now: Date): Date | null {
   const retryAfter = headers.get("Retry-After");
   if (!retryAfter) return null;
-  // TODO
-  return new Date();
+
+  const value = retryAfter.trim();
+  if (value.length === 0) return null;
+
+  // delta-seconds (non-negative integer)
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    return new Date(now.getTime() + seconds * 1000);
+  }
+
+  // HTTP-date: ensure it's actually a date-like string (contains letters)
+  if (!/[a-zA-Z]/.test(value)) return null;
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return null;
+  return new Date(timestamp);
 }

--- a/util.ts
+++ b/util.ts
@@ -2,7 +2,10 @@
  * Parse the Retry-After header as per spec:
  * https://datatracker.ietf.org/doc/html/rfc9110#section-10.2.3
  */
-export function parseRetryAfter(headers: Headers, now: Date): Date | null {
+export function parseRetryAfter(
+  headers: Headers,
+  now: Date = new Date(),
+): Date | null {
   const retryAfter = headers.get("Retry-After");
   if (!retryAfter) return null;
 

--- a/util.ts
+++ b/util.ts
@@ -1,0 +1,10 @@
+/**
+ * Parse the Retry-After header as per spec:
+ * https://datatracker.ietf.org/doc/html/rfc9110#section-10.2.3
+ */
+export function parseRetryAfter(headers: Headers, now: Date): Date | null {
+  const retryAfter = headers.get("Retry-After");
+  if (!retryAfter) return null;
+  // TODO
+  return new Date();
+}

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,0 +1,147 @@
+import { parseRetryAfter } from "./util.ts";
+import { assertEquals } from "jsr:@std/assert";
+
+Deno.test("parseRetryAfter", async (t) => {
+  // RFC 7231: Delay in seconds format
+  await t.step("Retry-After: 0 (zero delay)", () => {
+    const headers = new Headers({ "Retry-After": "0" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(now.getTime());
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  await t.step("Retry-After: 120 (2 minutes)", () => {
+    const headers = new Headers({ "Retry-After": "120" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(now.getTime() + 120 * 1000);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  await t.step("Retry-After: 86400 (24 hours)", () => {
+    const headers = new Headers({ "Retry-After": "86400" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(now.getTime() + 86400 * 1000);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  // RFC 7231: HTTP-date format
+  await t.step("Retry-After: HTTP-date format", () => {
+    const httpDate = "Fri, 31 Dec 2024 23:59:59 GMT";
+    const headers = new Headers({ "Retry-After": httpDate });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(httpDate);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  await t.step("Retry-After: Alternative HTTP-date format", () => {
+    const httpDate = "Friday, 31-Dec-24 23:59:59 GMT";
+    const headers = new Headers({ "Retry-After": httpDate });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(httpDate);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  await t.step("Retry-After: RFC 850 date format", () => {
+    const httpDate = "Fri Dec 31 23:59:59 2024";
+    const headers = new Headers({ "Retry-After": httpDate });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(httpDate);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  // Edge cases and invalid inputs
+  await t.step("Retry-After: negative delay should be invalid", () => {
+    const headers = new Headers({ "Retry-After": "-10" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    assertEquals(retryAfter, null);
+  });
+
+  await t.step("Retry-After: non-numeric string", () => {
+    const headers = new Headers({ "Retry-After": "abc" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    assertEquals(retryAfter, null);
+  });
+
+  await t.step("Retry-After: invalid date format", () => {
+    const headers = new Headers({ "Retry-After": "Invalid Date String" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    assertEquals(retryAfter, null);
+  });
+
+  await t.step(
+    "Retry-After: decimal number should be treated as invalid",
+    () => {
+      const headers = new Headers({ "Retry-After": "120.5" });
+      const now = new Date();
+      const retryAfter = parseRetryAfter(headers, now);
+      assertEquals(retryAfter, null);
+    },
+  );
+
+  await t.step("Retry-After: number with leading/trailing whitespace", () => {
+    const headers = new Headers({ "Retry-After": "  120  " });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(now.getTime() + 120 * 1000);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  await t.step("Retry-After: HTTP-date with whitespace", () => {
+    const httpDate = "  Fri, 31 Dec 2024 23:59:59 GMT  ";
+    const headers = new Headers({ "Retry-After": httpDate });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(httpDate.trim());
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  // Missing or empty header
+  await t.step("Missing Retry-After header", () => {
+    const headers = new Headers();
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    assertEquals(retryAfter, null);
+  });
+
+  await t.step("Empty Retry-After header", () => {
+    const headers = new Headers({ "Retry-After": "" });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    assertEquals(retryAfter, null);
+  });
+
+  await t.step("Retry-After header with only whitespace", () => {
+    const headers = new Headers({ "Retry-After": "   " });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    assertEquals(retryAfter, null);
+  });
+
+  // Large values
+  await t.step("Retry-After: very large delay", () => {
+    const headers = new Headers({ "Retry-After": "2147483647" }); // Max 32-bit signed int
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(now.getTime() + 2147483647 * 1000);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+
+  // Past date handling
+  await t.step("Retry-After: past HTTP-date", () => {
+    const pastDate = "Fri, 31 Dec 2020 23:59:59 GMT";
+    const headers = new Headers({ "Retry-After": pastDate });
+    const now = new Date();
+    const retryAfter = parseRetryAfter(headers, now);
+    const expected = new Date(pastDate);
+    assertEquals(retryAfter?.getTime(), expected.getTime());
+  });
+});


### PR DESCRIPTION
This PR adds a `retryAfter` property to the `AcmeError` class, allowing library users to make informed decisions about when to retry failed ACME operations.
